### PR TITLE
Issue 5

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore ./Code/Synnotech.MsSqlServer.sln
     - name: Build

--- a/Code/Synnotech.MsSqlServer.Tests/Synnotech.MsSqlServer.Tests.csproj
+++ b/Code/Synnotech.MsSqlServer.Tests/Synnotech.MsSqlServer.Tests.csproj
@@ -8,19 +8,15 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Synnotech.MsSqlServer\Synnotech.MsSqlServer.csproj" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Synnotech.Xunit" Version="1.1.0" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-        <PackageReference Include="Light.GuardClauses" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
         <PackageReference Include="Light.EmbeddedResources" Version="1.1.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Code/Synnotech.MsSqlServer/Synnotech.MsSqlServer.csproj
+++ b/Code/Synnotech.MsSqlServer/Synnotech.MsSqlServer.csproj
@@ -37,12 +37,9 @@ Synntech.MsSqlServer 2.0.0
         <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
         <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="Synnotech.DatabaseAbstractions" Version="3.0.0" />
-        <PackageReference Include="Light.GuardClauses" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Light.GuardClauses" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- The `KillAllDatabaseConnectionsAsync` method now only kills sessions where `is_user_process = 1`
- `TryCreateDatabaseAsync`, `TryDropDatabaseAsync`, and `DropAndCreateDatabaseAsync` now implement retry strategies to accomodate for SQL system processes interfering with database creation
- The retry strategy default to 3 retries with 750ms between each retry
- updated NuGet packages to newest versions
- updated build-and-test.yml to use .NET 6